### PR TITLE
fix command line to generate togostanza

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ LIMIT 100
 JavaScript version
 
 ```
-% rdf-config --config config/hint --stanza_rb hint_pair_stanza
+% rdf-config --config config/hint --stanza hint_pair
 Stanza template has been generated successfully.
 To view the stanza, run (cd stanza/javascript; ts server) and open http://localhost:8080/
 ```
@@ -141,7 +141,7 @@ To view the stanza, run (cd stanza/javascript; ts server) and open http://localh
 Ruby version (it may take a while for the first time to install dependencies)
 
 ```
-% rdf-config --config config/hint --stanza_rb hint_pair_stanza
+% rdf-config --config config/hint --stanza_rb hint_pair
 Stanza template has been generated successfully.
 To view the stanza, run (cd stanza/ruby; bundle exec rackup) and open http://localhost:9292/
 ```


### PR DESCRIPTION
Looks like the correct option for the js version is `--stanza`. The example stanza config file `config/hint/stanza.yaml` doesn't have `hint_pair_stanza` but does `hint_pair` instead.