### PR TITLE
修正しました。

### DIFF
--- a/config/dbnsfp/model.yaml
+++ b/config/dbnsfp/model.yaml
@@ -49,8 +49,8 @@
   - dbnsfp:conservationAlgorithm:
     - dbnsfp_conservation_algorithm: DbnsfpConservationAlgorithm
   - sio:SIO_000216+:
-    - phastcons100way_vertebrate_cscore1: Phastcons100wayVertebrateCscore
-    - phastcons100way_vertebrate_crankscore1: Phastcons100wayVertebrateCrankscore
+    - allele_conservation_cscore: Phastcons100wayVertebrateCscore
+    - allele_conservation_crankscore: Phastcons100wayVertebrateCrankscore
 
 - DamagePrediction dbnsfp_variation:grch38_1_65565_A_C_HUVEC_fitCons:
   - a: dbnsfp:DamagePrediction
@@ -81,12 +81,12 @@
 - Phastcons100wayVertebrateCscore dbnsfp_variation:grch38_1_65565_A_C_phastCons100way_vertebrate_cscore:
   - a: dbnsfp:ConservationScore
   - rdf:value:
-    - phastcons100way_vertebrate_cscore2: 0.993
+    - phastcons100way_vertebrate_cscore: 0.993
 
 - Phastcons100wayVertebrateCrankscore dbnsfp_variation:grch38_1_65565_A_C_phastCons100way_vertebrate_crankscore:
   - a: dbnsfp:ConservationRankScore
   - rdf:value:
-    - phastcons100way_vertebrate_crankscore2: 0.37899
+    - phastcons100way_vertebrate_crankscore: 0.37899
 
 - DbsnpVariationLocationGrch37 dbnsfp_faldo:grch37_1_65565:
   - a: faldo:ExactPosition
@@ -96,4 +96,3 @@
     - grch37_id: "grch37_1_65565"
   - dbnsfp:reference:
     - hco37: hco:GRCh37
-

--- a/config/dbnsfp/model.yaml
+++ b/config/dbnsfp/model.yaml
@@ -49,8 +49,8 @@
   - dbnsfp:conservationAlgorithm:
     - dbnsfp_conservation_algorithm: DbnsfpConservationAlgorithm
   - sio:SIO_000216+:
-    - phastcons100way_vertebrate_cscore: Phastcons100wayVertebrateCscore
-    - phastcons100way_vertebrate_crankscore: Phastcons100wayVertebrateCrankscore
+    - phastcons100way_vertebrate_cscore1: Phastcons100wayVertebrateCscore
+    - phastcons100way_vertebrate_crankscore1: Phastcons100wayVertebrateCrankscore
 
 - DamagePrediction dbnsfp_variation:grch38_1_65565_A_C_HUVEC_fitCons:
   - a: dbnsfp:DamagePrediction
@@ -81,12 +81,12 @@
 - Phastcons100wayVertebrateCscore dbnsfp_variation:grch38_1_65565_A_C_phastCons100way_vertebrate_cscore:
   - a: dbnsfp:ConservationScore
   - rdf:value:
-    - phastcons100way_vertebrate_cscore: 0.993
+    - phastcons100way_vertebrate_cscore2: 0.993
 
 - Phastcons100wayVertebrateCrankscore dbnsfp_variation:grch38_1_65565_A_C_phastCons100way_vertebrate_crankscore:
   - a: dbnsfp:ConservationRankScore
   - rdf:value:
-    - phastcons100way_vertebrate_crankscore: 0.37899
+    - phastcons100way_vertebrate_crankscore2: 0.37899
 
 - DbsnpVariationLocationGrch37 dbnsfp_faldo:grch37_1_65565:
   - a: faldo:ExactPosition

--- a/config/dbsnp/model.yaml
+++ b/config/dbsnp/model.yaml
@@ -1,4 +1,4 @@
-- dbSNPValiation dbsnp:1000017372:
+- DbSNPValiation dbsnp:1000017372:
   - a:
     - m2r:Variation
     - obo:SO_0001483
@@ -20,7 +20,7 @@
   - dct:hasPart:
     - allele: dbSNPAllele
 
-- dbSNPAllele dbsnp:1000017372#G:
+- DbSNPAllele dbsnp:1000017372#G:
   - a: dbsnpo:Allele
   - m2r:alternativeAllele:
     - alternative_allele: "G"

--- a/config/pubmed/model.yaml
+++ b/config/pubmed/model.yaml
@@ -1,7 +1,7 @@
 - Pubmed pubmed:31558841:
   - a: sio:SIO:000154
   - prism:doi:
-    - doi: "10.1038/s41431-019-0518-y"
+    - doi1: "10.1038/s41431-019-0518-y"
   - prism:eISSN:
     - eissn: "1476-5438"
   - prism:endingPage:
@@ -63,7 +63,7 @@
   - fabio:hasNationalLibraryOfMedicineJournalId:
     - nlm_id: "9302235"
   - fabio:hasPII:
-    - doi: "10.1038/s41431-019-0518-y"
+    - doi2: "10.1038/s41431-019-0518-y"
   - fabio:hasPlaceOfPublication:
     - place_of_publication: "England"
   - rdfs:seeAlso+:

--- a/config/pubmed/model.yaml
+++ b/config/pubmed/model.yaml
@@ -1,7 +1,7 @@
 - Pubmed pubmed:31558841:
   - a: sio:SIO:000154
   - prism:doi:
-    - doi1: "10.1038/s41431-019-0518-y"
+    - doi_prism: "10.1038/s41431-019-0518-y"
   - prism:eISSN:
     - eissn: "1476-5438"
   - prism:endingPage:
@@ -63,7 +63,7 @@
   - fabio:hasNationalLibraryOfMedicineJournalId:
     - nlm_id: "9302235"
   - fabio:hasPII:
-    - doi2: "10.1038/s41431-019-0518-y"
+    - doi: "10.1038/s41431-019-0518-y"
   - fabio:hasPlaceOfPublication:
     - place_of_publication: "England"
   - rdfs:seeAlso+:


### PR DESCRIPTION
>pubmedのdoiをdoi1とdoi2にしているところは、どちらがメインな属性かを考えて、主たる方はdoiのままにするほうが良いですね。

prismの方のdoiをdoi_prismとして、もう一方はdoiにしました。

>同様に、dbnsfpも機械的に1,2を振るのが本当に良いのでしょうか？1の方は主語が AlleleConservation なので、変数名を allele_conservation_cscore, allele_conservation_crankscore にするだけで良くないですか？

allele_conservation_cscore, allele_conservation_crankscoreに変更して、数字を取りました。