### PR TITLE
Updated metadata.yaml for BacDive and MediaDive

### DIFF
--- a/config/bacdive/metadata.yaml
+++ b/config/bacdive/metadata.yaml
@@ -1,12 +1,18 @@
 title: BacDive RDF
 website: https://bacdive.dsmz.de/
-description: BacDive is the worldwide largest database for standardized bacterial information. Its mission is to mobilize and integrate research data on strain level from diverse sources and make it freely accessible. 
+description: BacDive is the worldwide largest knowledgebase for standardized bacterial information. 
 tags: [ Organism, Cell, Bioresource ]
-provider: DSMZ
+provider: Leibniz Institute DSMZ-German Collection of Microorganisms and Cell Cultures
 creators:
   - name: Julia Koblitz
-    affiliation: DSMZ
-version: release_20251016
-issued: 2025-10-16
+    affiliation: Leibniz Institute DSMZ-German Collection of Microorganisms and Cell Cultures
+  - name: Lorenz Christian Reimer
+    affiliation: Leibniz Institute DSMZ-German Collection of Microorganisms and Cell Cultures
+  - name: Joaquim Sardá Carbasse
+    affiliation: Leibniz Institute DSMZ-German Collection of Microorganisms and Cell Cultures
+  - name: Isabel Schober
+    affiliation: Leibniz Institute DSMZ-German Collection of Microorganisms and Cell Cultures
+version: 2024_12
+issued: 2025-09-16
 licenses:
   - Creative Commons Attribution 4.0 International (CC BY 4.0)

--- a/config/mediadive/metadata.yaml
+++ b/config/mediadive/metadata.yaml
@@ -1,11 +1,11 @@
 title: MediaDive RDF
 website: https://mediadive.dsmz.de/
-description: MediaDive is the world's largest collection of cultivation media.
+description: MediaDive is the largest collection of cultivation media and growth conditions.
 tags: [ Organism, Cell, Bioresource ]
-provider: DSMZ
+provider: Leibniz Institute DSMZ-German Collection of Microorganisms and Cell Cultures
 creators:
   - name: Julia Koblitz
-    affiliation: DSMZ
+    affiliation: Leibniz Institute DSMZ-German Collection of Microorganisms and Cell Cultures
 version: release_20251016
 issued: 2025-10-16
 licenses:

--- a/config/mediadive/metadata.yaml
+++ b/config/mediadive/metadata.yaml
@@ -6,7 +6,7 @@ provider: Leibniz Institute DSMZ-German Collection of Microorganisms and Cell Cu
 creators:
   - name: Julia Koblitz
     affiliation: Leibniz Institute DSMZ-German Collection of Microorganisms and Cell Cultures
-version: release_20251016
-issued: 2025-10-16
+version: 2024-10
+issued: 2025-09-16
 licenses:
   - Creative Commons Attribution 4.0 International (CC BY 4.0)


### PR DESCRIPTION
This pull request updates metadata for both BacDive and MediaDive to provide more accurate and comprehensive descriptions, correct provider and creator information, and update release details. The changes improve clarity and ensure consistency with current institutional naming and contributor lists.

**Metadata updates for BacDive:**

* Updated the description to refer to BacDive as the "largest knowledgebase" instead of "largest database," reflecting its broader scope.
* Changed the provider name from `DSMZ` to the full institutional name `Leibniz Institute DSMZ-German Collection of Microorganisms and Cell Cultures`.
* Expanded the list of creators to include Lorenz Christian Reimer, Joaquim Sardá Carbasse, and Isabel Schober, all with correct affiliations.
* Updated the version and issued date.

**Metadata updates for MediaDive:**

* Revised the description to include "growth conditions" in addition to "cultivation media."
* Changed the provider name and creator affiliation to the full institutional name for consistency.
* Updated the version and issued date.